### PR TITLE
docker-compose 작성 및 application.yml 설정 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3'
+
+services:
+  mysql:
+    container_name: toyboard_mysql
+    image: mysql/mysql-server:latest
+    environment:
+      MYSQL_ROOT_HOST: '%'
+      MYSQL_USER: "toyboard"
+      MYSQL_PASSWORD: "toyboard8!@"
+      MYSQL_DATABASE: "toyboard"
+    ports:
+      - "3388:3306"
+    command:
+      - "mysqld"
+      - "--character-set-server=utf8mb4"
+      - "--collation-server=utf8mb4_unicode_ci"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,38 @@
+spring:
+  profiles:
+    active: local
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    url: jdbc:mysql://127.0.0.1:3388/toyboard
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: toyboard
+    password: toyboard8!@
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+---
+spring:
+  config:
+    activate:
+      on-profile: test
+  datasource:
+    url: jdbc:h2:mem:db;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    database: h2
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true


### PR DESCRIPTION
### `docker-compose.yml` 추가 - MySQL 이미지 기반
- 실행 : `docker-compose up -d`
- 도커 접속 : `docker exec -it [container-id] bash`
- 컨테이너 ID 확인 : `docker ps - a`

```
version: '3'

services:
  mysql:
    container_name: toyboard_mysql
    image: mysql/mysql-server:latest
    environment:
      MYSQL_ROOT_HOST: '%'
      MYSQL_USER: "toyboard"
      MYSQL_PASSWORD: "toyboard8!@"
      MYSQL_DATABASE: "toyboard"
    ports:
      - "3388:3306"
    command:
      - "mysqld"
      - "--character-set-server=utf8mb4"
      - "--collation-server=utf8mb4_unicode_ci"
```

### `application.yml` 설정 추가

- DB 포트 : 3388 (8조니까)

```yaml
spring:
  profiles:
    active: local
---
spring:
  config:
    activate:
      on-profile: local
  datasource:
    url: jdbc:mysql://127.0.0.1:3388/toyboard
    driver-class-name: com.mysql.cj.jdbc.Driver
    username: toyboard
    password: toyboard8!@
  jpa:
    show-sql: true
    hibernate:
      ddl-auto: create
    properties:
      hibernate:
        format_sql: true
---
spring:
  config:
    activate:
      on-profile: test
  datasource:
    url: jdbc:h2:mem:db;DB_CLOSE_DELAY=-1
    driver-class-name: org.h2.Driver
    username: sa
    password:
  jpa:
    database: h2
    show-sql: true
    hibernate:
      ddl-auto: create
    properties:
      hibernate:
        format_sql: true
```