### PR TITLE
Thymeleaf Template Engine 추가 및 기본 설정 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.3.1'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'

--- a/build.gradle
+++ b/build.gradle
@@ -1,41 +1,41 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '2.7.13'
-	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id 'java'
+    id 'org.springframework.boot' version '2.7.13'
+    id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 }
 
 group = 'com.fastcampus'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '11'
+    sourceCompatibility = '11'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.3.1'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.3.1'
-	testImplementation 'org.springframework.security:spring-security-test'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.3.1'
+    compileOnly 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.3.1'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
-tasks.named('test') {
-	useJUnitPlatform()
+test {
+    useJUnitPlatform()
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3'
+
+services:
+  mysql:
+    container_name: toyboard_mysql
+    image: mysql/mysql-server:latest
+    environment:
+      MYSQL_ROOT_HOST: '%'
+      MYSQL_USER: "toyboard"
+      MYSQL_PASSWORD: "toyboard8!@"
+      MYSQL_DATABASE: "toyboard"
+    ports:
+      - "3388:3306"
+    command:
+      - "mysqld"
+      - "--character-set-server=utf8mb4"
+      - "--collation-server=utf8mb4_unicode_ci"

--- a/src/main/java/com/fastcampus/toyboard/ToyboardApplication.java
+++ b/src/main/java/com/fastcampus/toyboard/ToyboardApplication.java
@@ -2,8 +2,10 @@ package com.fastcampus.toyboard;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class ToyboardApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/fastcampus/toyboard/ToyboardApplication.java
+++ b/src/main/java/com/fastcampus/toyboard/ToyboardApplication.java
@@ -8,8 +8,7 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 @ConfigurationPropertiesScan
 public class ToyboardApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(ToyboardApplication.class, args);
-	}
-
+  public static void main(String[] args) {
+    SpringApplication.run(ToyboardApplication.class, args);
+  }
 }

--- a/src/main/java/com/fastcampus/toyboard/config/ThymeleafConfig.java
+++ b/src/main/java/com/fastcampus/toyboard/config/ThymeleafConfig.java
@@ -1,0 +1,31 @@
+package com.fastcampus.toyboard.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.thymeleaf.spring5.templateresolver.SpringResourceTemplateResolver;
+
+@Configuration
+public class ThymeleafConfig {
+
+  @Bean
+  public SpringResourceTemplateResolver thymeleafTemplateResolver(
+      SpringResourceTemplateResolver defaultTemplateResolver,
+      Thymeleaf3Properties thymeleaf3Properties) {
+    defaultTemplateResolver.setUseDecoupledLogic(thymeleaf3Properties.isDecoupledLogic());
+
+    return defaultTemplateResolver;
+  }
+
+  @RequiredArgsConstructor
+  @ConfigurationProperties("spring.thymeleaf3")
+  @ConstructorBinding
+  @Getter
+  public static class Thymeleaf3Properties {
+    /** Use Thymeleaf 3 Decoupled Logic */
+    private final boolean decoupledLogic;
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,8 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  thymeleaf3:
+    decoupledLogic: true
 ---
 spring:
   config:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,38 @@
+spring:
+  profiles:
+    active: local
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    url: jdbc:mysql://127.0.0.1:3388/toyboard
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: toyboard
+    password: toyboard8!@
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+---
+spring:
+  config:
+    activate:
+      on-profile: test
+  datasource:
+    url: jdbc:h2:mem:db;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    database: h2
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,16 @@ spring:
         format_sql: true
   thymeleaf3:
     decoupledLogic: true
+#Live Reload 기능 활성화
+  devtools:
+    livereload:
+      enabled: true
+  thymeleaf:
+    cache: false
+    prefix: file:src/main/resources/templates/
+  web:
+    resources:
+      static-locations: file:src/main/resources/static/
 ---
 spring:
   config:


### PR DESCRIPTION
## Work details

- Thymeleaf Template Engine Dependency 추가
- Decoupled Logic 적용을 위한 Configuration 클래스 및 설정 추가

## Why ?

- Thymeleaf -> Decouple Logic 적용을 통해 html, css (design part) 와 thymeleaf 를 통한 데이터 적용 (data part) 을 분리할 수 있음.
- Design 이 완료된 Mockup page 만 만들어두고 각 도메인 담당 개발자가 thymeleaf template 파일을 통해 데이터만 적절하게 넣어주면 페이지 완성됨.